### PR TITLE
league_provider.dart에서 상태 초기화 시 사용하는 리그 코드명 오타 수정

### DIFF
--- a/frontend/lib/providers/league_provider.dart
+++ b/frontend/lib/providers/league_provider.dart
@@ -43,7 +43,7 @@ class LeagueProvider extends ChangeNotifier {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _selectedIndex = 0;
       _selectedLeagueName = '프리미어리그';
-      _selectedLeagueCode = 'PR';
+      _selectedLeagueCode = 'PL';
       notifyListeners();
     });
   }


### PR DESCRIPTION
-  resetSelectionForLeague 메서드에서 'PR'을 'PL'로 수정